### PR TITLE
Update pom.xml to deploy to aws s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ job on master in this repo).
 
 # Local installation
 
-1. Modify `rv-install.version` property in `build.xml` to the version that you want to install locally.  
-2. Run `sh install.sh ${version_in_step_1}`
+1. Modify `rv-install.version` property in `pom.xml` to the version that you want to install locally.  
+2. Run `mvn install`
 
 # Deployment
 
-1. Modify `rv-install.version` property in `build.xml` to the version that you want to deploy remotely.
-2. Run `sh deploy.sh ${version_in_step_1}`
+1. Modify `rv-install.version` property in `pom.xml` to the version that you want to deploy remotely.
+2. Run `mvn deploy`
 
 # Methodology
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,34 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
+  <repositories>
+    <repository>
+      <id>runtime.verification</id>
+      <name>Runtime Verification Repository</name>
+      <url>https://s3.amazonaws.com/repo.runtime.verification/repository/internal</url>
+      <snapshots><enabled>false</enabled></snapshots>
+      <releases><enabled>true</enabled></releases>
+    </repository>
+    <repository>
+      <id>runtime.verification.snapshots</id>
+      <name>Runtime Verification Snapshot Repository</name>
+      <url>https://s3.amazonaws.com/repo.runtime.verification/repository/snapshots</url>
+      <snapshots><enabled>true</enabled></snapshots>
+      <releases><enabled>false</enabled></releases>
+    </repository>
+  </repositories>
+  <distributionManagement>
+    <repository>
+      <id>runtime.verification</id>
+      <name>JavaMop Repository</name>
+      <url>s3://repo.runtime.verification/repository/internal</url>
+    </repository>
+    <snapshotRepository>
+      <id>runtime.verification.snapshots</id>
+      <name>JavaMop Snapshot Repository</name>
+      <url>s3://repo.runtime.verification/repository/snapshots</url>
+    </snapshotRepository>
+  </distributionManagement>
   <dependencies>
     <dependency>
       <groupId>com.runtimeverification.licensing</groupId>


### PR DESCRIPTION
@dwightguth 

I added `<repositories>` and `<distributionManagement>`  to `pom.xml`.  
It is okay to add both of them at the same time because `<repositories>` is only used to download `rv-licensing` from aws s3.
